### PR TITLE
[fix] path パラメータの記載漏れを修正

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -121,6 +121,8 @@ paths:
       operationId: patchFollowing
       tags:
         - follows
+      parameters:
+        - $ref: ./components/parameters/user-id-path.yml
       requestBody:
         required: true
         content:


### PR DESCRIPTION
openapi にミスがあったので修正しました。

メソッドによってはパスパラメーターの記載が漏れてました。
この辺の、メソッドに共通のものって定義する方法ないですかね。。。？

