### PR TITLE
サーバーのデフォルト host を 0.0.0.0 に変更

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -3,7 +3,7 @@ package config
 import "os"
 
 const (
-	defaultHost = "localhost"
+	defaultHost = "0.0.0.0"
 	defaultPort = "8080"
 )
 


### PR DESCRIPTION
localhost をしている状態では、同じネットワークの他の端末からアクセスができなかった。

そこで**すべてのネットワーク・インターフェースを表す** `0.0.0.0` に変更する。

## 参考

- [127.0.0.1とlocalhostと0.0.0.0の違い](https://qiita.com/1ain2/items/194a9372798eaef6c5ab)
- [What is the difference between 0.0.0.0, 127.0.0.1 and localhost?](https://stackoverflow.com/questions/20778771/what-is-the-difference-between-0-0-0-0-127-0-0-1-and-localhost)
